### PR TITLE
Implemented function to delete all user activities

### DIFF
--- a/src/main/kotlin/ie/setu/controllers/HealthTrackerController.kt
+++ b/src/main/kotlin/ie/setu/controllers/HealthTrackerController.kt
@@ -99,6 +99,16 @@ object HealthTrackerController {
         ctx.json(activity)
     }
 
+    fun deleteAllUserActivities(ctx: Context) {
+        val userId = ctx.pathParam("user-id").toInt()
+        
+        val user = userDao.findById(userId)
+        if (user != null) {
+            activityDAO.deleteUserActivities(userId)
+        }
+    }
+
+
 
 }
 

--- a/src/main/kotlin/ie/setu/domain/repository/ActivityDAO.kt
+++ b/src/main/kotlin/ie/setu/domain/repository/ActivityDAO.kt
@@ -50,4 +50,12 @@ class ActivityDAO {
         }
     }
 
+    //Delete all activities associated with a user
+    fun deleteUserActivities(userId: Int){
+        transaction {
+            Activities.deleteWhere { Activities.userId eq userId }
+        }
+    }
+
+
 }


### PR DESCRIPTION
This commit adds the `deleteAllUserActivities` function in the HealthTrackerController, which allows for the deletion of all activities associated with a specific user.

Closes #8